### PR TITLE
Add index checkin, checkout

### DIFF
--- a/app/Models/Setting.php
+++ b/app/Models/Setting.php
@@ -22,10 +22,10 @@ class Setting extends Model
 
     public const VERSION = '1.0';
 
-    protected static function booted()
-    {
-        static::saved(function () {
-            Cache::tags(['settings'])->flush();
-        });
-    }
+    // protected static function booted()
+    // {
+    //     static::saved(function () {
+    //         Cache::tags(['settings'])->flush();
+    //     });
+    // }
 }

--- a/app/Rules/GuestCapacityRule.php
+++ b/app/Rules/GuestCapacityRule.php
@@ -19,8 +19,7 @@ class GuestCapacityRule implements ValidationRule
      */
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
-        $capacity = RoomType::where($this->room_type_id)->value('capacity');
-
+        $capacity = RoomType::where('id', $this->room_type_id)->value('capacity');
         if ($capacity !== null && $value > $capacity) {
             $fail('The selected room type does not have enough capacity.')->translate();
         }

--- a/database/migrations/2025_01_19_020456_create_bookings_table.php
+++ b/database/migrations/2025_01_19_020456_create_bookings_table.php
@@ -21,6 +21,13 @@ return new class extends Migration
             $table->date('check_out');
             $table->decimal('total_price', 10, 2);
             $table->timestamps();
+
+            // Index the check_in and check_out columns
+            $table->index('check_in');
+            $table->index('check_out');
+
+            // Index the check_in and check_out columns together
+            $table->index(['check_in', 'check_out']);
         });
     }
 

--- a/database/migrations/2025_01_19_020456_create_bookings_table.php
+++ b/database/migrations/2025_01_19_020456_create_bookings_table.php
@@ -22,10 +22,6 @@ return new class extends Migration
             $table->decimal('total_price', 10, 2);
             $table->timestamps();
 
-            // Index the check_in and check_out columns
-            $table->index('check_in');
-            $table->index('check_out');
-
             // Index the check_in and check_out columns together
             $table->index(['check_in', 'check_out']);
         });

--- a/database/migrations/2025_01_19_020456_create_bookings_table.php
+++ b/database/migrations/2025_01_19_020456_create_bookings_table.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
@@ -21,6 +22,20 @@ return new class extends Migration
             $table->date('check_out');
             $table->decimal('total_price', 10, 2);
             $table->timestamps();
+
+            $version = DB::selectOne('SELECT VERSION() as version')->version;
+
+            preg_match('/(\d+\.\d+)/', $version, $matches);
+            $numericVersion = isset($matches[1]) ? (float) $matches[1] : 0;
+
+            if ($numericVersion >= 8.0 || str_contains($version, 'MariaDB') && $numericVersion >= 10.6) {
+                // support for MySQL 8.0 and MariaDB 10.6 and up
+                $table->index('check_in')->withStats();
+                $table->index('check_out')->withStats();
+            } else {
+                $table->index('check_in');
+                $table->index('check_out');
+            }
 
             // Index the check_in and check_out columns together
             $table->index(['check_in', 'check_out']);


### PR DESCRIPTION
## Summary by Sourcery

Add indices to the `bookings` table for `check_in` and `check_out` columns, individually and combined. Remove cache flushing on setting save.

New Features:
- Add database indices to improve query performance for bookings.

Enhancements:
- Remove unnecessary cache flushing for settings.